### PR TITLE
support tilde in url opener

### DIFF
--- a/lua/open/default_openers.lua
+++ b/lua/open/default_openers.lua
@@ -36,7 +36,7 @@ end
 ---@param text string text to look for valid URL
 ---@return string|nil _ the URL
 M.url = function(text)
-    return text:match("[http://][https://][http://www.][https://www.]+%w+%.%w+[/%w_%.%-]+")
+    return text:match("[http://][https://][http://www.][https://www.]+%w+%.%w+[/%w_%.%-%~]+")
 end
 
 return M


### PR DESCRIPTION
This PR adds support for tilde in URL subdirectories, such as:
https://git.sr.ht/~whynothugo/lsp_lines.nvim