### PR TITLE
Add support for several url chars

### DIFF
--- a/lua/open/openers/url.lua
+++ b/lua/open/openers/url.lua
@@ -9,7 +9,7 @@ M.name = 'url'
 ---@return string[]|nil _ the URL
 M.open_fn = function(text)
     local urls = {}
-    for url in text:gmatch("[http://][https://][http://www.][https://www.]+%w+%.%w+[/%w_%.%-%~]+") do
+    for url in text:gmatch("[http://][https://][http://www.][https://www.]+%w+%.%w+[/%w_%.%-%~%?%+%%&#=:]+") do
         table.insert(urls, url)
     end
 


### PR DESCRIPTION
Hi, this PR adds support for the following characters in urls: ?+%&#=:

Here are some URLs I tested with:

https://github.com/ofirgall/open.nvim#installation

https://vim.fandom.com/wiki/Search_for_lines_not_containing_pattern_and_other_helpful_searches#Using_the_:v_command

https://duckduckgo.com/?q=lua+%22pattern%22&t=ffab&ia=web
